### PR TITLE
Add skeleton modules for call graph traversal

### DIFF
--- a/rplugin/python3/callgraphite/capture.py
+++ b/rplugin/python3/callgraphite/capture.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Utilities for extracting source code from the current buffer."""
+from typing import Optional
+from pynvim import Nvim
+
+
+def get_current_function_text(nvim: Nvim) -> Optional[str]:
+    """Return the text of the function under the cursor.
+
+    The implementation relies on tree-sitter to locate the nearest parent
+    function node and then extracts the lines for that range. This function
+    mirrors the Lua snippet used in the ``CaptureFunction`` command but is
+    presented here as a reusable Python helper.
+    """
+    # TODO: Implement tree-sitter based extraction.
+    return None
+

--- a/rplugin/python3/callgraphite/llm.py
+++ b/rplugin/python3/callgraphite/llm.py
@@ -1,0 +1,20 @@
+"""Abstractions for interacting with a language model service."""
+from typing import Any
+
+
+class LLMClient:
+    """Placeholder client used to send prompts to an LLM."""
+
+    def __init__(self, endpoint: str | None = None) -> None:
+        self.endpoint = endpoint
+        # TODO: Store authentication details or session objects here.
+
+    def analyse_function(self, source: str) -> Any:
+        """Analyse a block of source code and return key strings.
+
+        In a real implementation this method would make a request to the LLM
+        and return the parsed response.
+        """
+        # TODO: Implement LLM request logic.
+        return None
+

--- a/rplugin/python3/callgraphite/traversal.py
+++ b/rplugin/python3/callgraphite/traversal.py
@@ -1,0 +1,48 @@
+"""Call graph traversal logic using LSP and LLM analysis."""
+from __future__ import annotations
+
+from typing import Set
+from pynvim import Nvim
+
+from .capture import get_current_function_text
+from .llm import LLMClient
+
+
+class TraversalManager:
+    """Coordinate DFS traversal of functions within a project."""
+
+    def __init__(self, nvim: Nvim, llm: LLMClient) -> None:
+        self.nvim = nvim
+        self.llm = llm
+        self.visited: Set[str] = set()
+
+    def run(self) -> None:
+        """Start traversal from the function under the cursor."""
+        source = get_current_function_text(self.nvim)
+        if source is None:
+            self.nvim.out_write("No root function found\n")
+            return
+        self.visit_function("<root>", source)
+
+    def visit_function(self, symbol: str, source: str) -> None:
+        """Analyse ``source`` and recursively visit its callees."""
+        if symbol in self.visited:
+            return
+        self.visited.add(symbol)
+
+        self.llm.analyse_function(source)
+        # TODO: Query LSP for called functions and iterate over them.
+        # for child_symbol in self._called_functions(symbol):
+        #     child_source = ...
+        #     self.visit_function(child_symbol, child_source)
+
+    # def _called_functions(self, symbol: str) -> Iterable[str]:
+    #     """Return the names of functions called by ``symbol`` via LSP."""
+    #     pass
+
+
+def traverse_project(nvim: Nvim) -> None:
+    """Helper used by the ``:CallGraphite`` command."""
+    manager = TraversalManager(nvim, LLMClient())
+    manager.run()
+


### PR DESCRIPTION
## Summary
- outline skeleton modules for capturing function text, LLM integration and traversal
- refactor plugin to use new helpers and expose `:CallGraphite` command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683feeb565b08324b7ac5d0d8abd1b7c