### PR TITLE
Add jump stack navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ You can also capture the text of the function under the cursor using:
 
 This command uses tree-sitter to locate the nearest parent function and prints its source.
 
+Navigation through analysed locations is possible using:
+
+```
+:CallGraphiteBack
+:CallGraphiteForward
+```
+
+These commands move through the internal jump stack maintained by the plugin, mirroring Neovim's own jump list.
+
 
 ## Running Tests
 

--- a/rplugin/python3/callgraphite/__init__.py
+++ b/rplugin/python3/callgraphite/__init__.py
@@ -3,7 +3,7 @@
 from pynvim import command, plugin
 
 from .capture import get_current_function_text
-from .traversal import traverse_project
+from .traversal import TraversalManager, traverse_project
 
 @plugin
 class CallGraphitePlugin:
@@ -11,6 +11,7 @@ class CallGraphitePlugin:
 
     def __init__(self, nvim):
         self.nvim = nvim
+        self.manager: TraversalManager | None = None
 
     @command('CaptureFunction', nargs='0', range='')
     def capture_function(self, args, range):
@@ -24,7 +25,19 @@ class CallGraphitePlugin:
     @command('CallGraphite', nargs='0', range='')
     def call_graphite(self, args, range):
         """Traverse the project and analyse functions via an LLM."""
-        traverse_project(self.nvim)
+        self.manager = traverse_project(self.nvim)
+
+    @command('CallGraphiteBack', nargs='0', range='')
+    def call_graphite_back(self, args, range):
+        """Move back in the traversal stack."""
+        if self.manager:
+            self.manager.jumps.back()
+
+    @command('CallGraphiteForward', nargs='0', range='')
+    def call_graphite_forward(self, args, range):
+        """Move forward in the traversal stack."""
+        if self.manager:
+            self.manager.jumps.forward()
 
 
 

--- a/rplugin/python3/callgraphite/traversal.py
+++ b/rplugin/python3/callgraphite/traversal.py
@@ -1,11 +1,49 @@
 """Call graph traversal logic using LSP and LLM analysis."""
 from __future__ import annotations
 
-from typing import Set
+from typing import Iterable, List, Set, Tuple
 from pynvim import Nvim
 
 from .capture import get_current_function_text
 from .llm import LLMClient
+
+
+class JumpStack:
+    """Maintain jump history for forward/backward navigation."""
+
+    def __init__(self, nvim: Nvim) -> None:
+        self.nvim = nvim
+        self.stack: List[Tuple[str, int, int]] = []
+        self.index: int = -1
+
+    def _jump(self, path: str, line: int, col: int) -> None:
+        """Perform a jump within Neovim."""
+        self.nvim.command(f"keepjumps edit {path}")
+        self.nvim.call("cursor", line, col)
+
+    def push(self, path: str, line: int, col: int) -> None:
+        """Jump to ``path`` and record the location."""
+        if self.index < len(self.stack) - 1:
+            self.stack = self.stack[: self.index + 1]
+        self.stack.append((path, line, col))
+        self.index += 1
+        self._jump(path, line, col)
+
+    def back(self) -> None:
+        """Jump backward in the history if possible."""
+        if self.index <= 0:
+            return
+        self.index -= 1
+        path, line, col = self.stack[self.index]
+        self._jump(path, line, col)
+
+    def forward(self) -> None:
+        """Jump forward in the history if possible."""
+        if self.index + 1 >= len(self.stack):
+            return
+        self.index += 1
+        path, line, col = self.stack[self.index]
+        self._jump(path, line, col)
 
 
 class TraversalManager:
@@ -15,6 +53,14 @@ class TraversalManager:
         self.nvim = nvim
         self.llm = llm
         self.visited: Set[str] = set()
+        self.jumps = JumpStack(nvim)
+
+    def _cursor_location(self) -> Tuple[str, int, int]:
+        """Return the current buffer path, line and column."""
+        path = self.nvim.current.buffer.name
+        line = int(self.nvim.funcs.line('.'))
+        col = int(self.nvim.funcs.col('.'))
+        return path, line, col
 
     def run(self) -> None:
         """Start traversal from the function under the cursor."""
@@ -22,6 +68,7 @@ class TraversalManager:
         if source is None:
             self.nvim.out_write("No root function found\n")
             return
+        self.jumps.push(*self._cursor_location())
         self.visit_function("<root>", source)
 
     def visit_function(self, symbol: str, source: str) -> None:
@@ -31,18 +78,27 @@ class TraversalManager:
         self.visited.add(symbol)
 
         self.llm.analyse_function(source)
-        # TODO: Query LSP for called functions and iterate over them.
-        # for child_symbol in self._called_functions(symbol):
-        #     child_source = ...
-        #     self.visit_function(child_symbol, child_source)
+        for uri, line, col in self._called_functions(symbol):
+            self.jumps.push(uri, line, col)
+            child_source = get_current_function_text(self.nvim)
+            if child_source:
+                child_symbol = f"{uri}:{line}:{col}"
+                self.visit_function(child_symbol, child_source)
+            self.jumps.back()
+
+    def _called_functions(self, symbol: str) -> Iterable[Tuple[str, int, int]]:
+        """Return locations of functions referenced by ``symbol``."""
+        # TODO: Implement real LSP queries. ``symbol`` is unused for now.
+        return []
 
     # def _called_functions(self, symbol: str) -> Iterable[str]:
     #     """Return the names of functions called by ``symbol`` via LSP."""
     #     pass
 
 
-def traverse_project(nvim: Nvim) -> None:
+def traverse_project(nvim: Nvim) -> TraversalManager:
     """Helper used by the ``:CallGraphite`` command."""
     manager = TraversalManager(nvim, LLMClient())
     manager.run()
+    return manager
 

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -4,14 +4,30 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "rplugin/python3"))
 
 from callgraphite import CallGraphitePlugin
+from callgraphite.traversal import JumpStack
 
 class DummyNvim:
     def exec_lua(self, script):
         return ''
     def out_write(self, msg):
         self.last_msg = msg
+    def command(self, cmd):
+        self.last_cmd = cmd
+    def call(self, name, *args):
+        self.last_call = (name, args)
 
 
 def test_plugin_import():
     plugin = CallGraphitePlugin(DummyNvim())
     assert hasattr(plugin, 'capture_function')
+
+
+def test_jump_stack_navigation():
+    nvim = DummyNvim()
+    js = JumpStack(nvim)
+    js.push('file_a', 1, 1)
+    js.push('file_b', 2, 1)
+    js.back()
+    assert js.index == 0
+    js.forward()
+    assert js.index == 1


### PR DESCRIPTION
## Summary
- integrate a `JumpStack` helper for path-based navigation
- wire jump navigation into `TraversalManager`
- expose `CallGraphiteBack`/`CallGraphiteForward` commands
- document navigation commands in README
- cover JumpStack with tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff52799908324a9e0d10f17cf51e7